### PR TITLE
eschews JSON.stringify() for custom string join.  purpose: spaces

### DIFF
--- a/ng-annotate-main.js
+++ b/ng-annotate-main.js
@@ -84,12 +84,16 @@ function matchProp(name, props) {
     return null;
 }
 
+function stringify(arr) {
+    return "[" + arr.map(function(arg) {
+        return '"' + arg.name + '"';
+    }).join(", ") + "]";
+}
+
 function insertArray(functionExpression, fragments) {
     const range = functionExpression.range;
 
-    const args = JSON.stringify(functionExpression.params.map(function(arg) {
-        return arg.name;
-    }));
+    const args = stringify(functionExpression.params);
     fragments.push({
         start: range[0],
         end: range[0],
@@ -108,9 +112,7 @@ function replaceArray(array, fragments) {
     if (functionExpression.params.length === 0) {
         return removeArray(array, fragments);
     }
-    const args = JSON.stringify(functionExpression.params.map(function(arg) {
-        return arg.name;
-    }));
+    const args = stringify(functionExpression.params);
     fragments.push({
         start: array.range[0],
         end: functionExpression.range[0],

--- a/tests/with_annotations.js
+++ b/tests/with_annotations.js
@@ -1,25 +1,25 @@
 "use strict";
 
 // long form
-angular.module("MyMod").controller("MyCtrl", ["$scope","$timeout", function($scope, $timeout) {
+angular.module("MyMod").controller("MyCtrl", ["$scope", "$timeout", function($scope, $timeout) {
 }]);
 
 // w/ dependencies
-angular.module("MyMod", ["OtherMod"]).controller("MyCtrl", ["$scope","$timeout", function($scope, $timeout) {
+angular.module("MyMod", ["OtherMod"]).controller("MyCtrl", ["$scope", "$timeout", function($scope, $timeout) {
 }]);
 
 // simple
-myMod.controller("foo", ["$scope","$timeout", function($scope, $timeout) {
+myMod.controller("foo", ["$scope", "$timeout", function($scope, $timeout) {
 }]);
-myMod.service("foo", ["$scope","$timeout", function($scope, $timeout) {
+myMod.service("foo", ["$scope", "$timeout", function($scope, $timeout) {
 }]);
-myMod.factory("foo", ["$scope","$timeout", function($scope, $timeout) {
+myMod.factory("foo", ["$scope", "$timeout", function($scope, $timeout) {
 }]);
-myMod.directive("foo", ["$scope","$timeout", function($scope, $timeout) {
+myMod.directive("foo", ["$scope", "$timeout", function($scope, $timeout) {
 }]);
-myMod.filter("foo", ["$scope","$timeout", function($scope, $timeout) {
+myMod.filter("foo", ["$scope", "$timeout", function($scope, $timeout) {
 }]);
-myMod.animation("foo", ["$scope","$timeout", function($scope, $timeout) {
+myMod.animation("foo", ["$scope", "$timeout", function($scope, $timeout) {
 }]);
 
 // no dependencies => no need to wrap the function in an array
@@ -37,11 +37,11 @@ myMod.animation("foo", function() {
 });
 
 // run, config don't take names
-myMod.run(["$scope","$timeout", function($scope, $timeout) {
+myMod.run(["$scope", "$timeout", function($scope, $timeout) {
 }]);
 angular.module("MyMod").run(["$scope", function($scope) {
 }]);
-myMod.config(["$scope","$timeout", function($scope, $timeout) {
+myMod.config(["$scope", "$timeout", function($scope, $timeout) {
 }]);
 angular.module("MyMod").config(function() {
 });
@@ -49,7 +49,7 @@ angular.module("MyMod").config(function() {
 // directive return object
 myMod.directive("foo", ["$scope", function($scope) {
     return {
-        controller: ["$scope","$timeout", function($scope, $timeout) {
+        controller: ["$scope", "$timeout", function($scope, $timeout) {
             bar;
         }]
     }
@@ -64,7 +64,7 @@ myMod.directive("foo", ["$scope", function($scope) {
 
 // provider, provider $get
 myMod.provider("foo", ["$scope", function($scope) {
-    this.$get = ["$scope","$timeout", function($scope, $timeout) {
+    this.$get = ["$scope", "$timeout", function($scope, $timeout) {
         bar;
     }];
 }]);
@@ -75,7 +75,7 @@ myMod.provider("foo", function() {
 });
 myMod.provider("foo", function() {
     return {
-        $get: ["$scope","$timeout", function($scope, $timeout) {
+        $get: ["$scope", "$timeout", function($scope, $timeout) {
             bar;
         }]};
 });
@@ -86,7 +86,7 @@ myMod.provider("foo", function() {
         }};
 });
 myMod.provider("foo", {
-    $get: ["$scope","$timeout", function($scope, $timeout) {
+    $get: ["$scope", "$timeout", function($scope, $timeout) {
         bar;
     }]
 });
@@ -97,23 +97,23 @@ myMod.provider("foo", {
 });
 
 // chaining
-myMod.directive("foo", ["$a","$b", function($a, $b) {
+myMod.directive("foo", ["$a", "$b", function($a, $b) {
     a;
 }]).factory("foo", function() {
         b;
     }).config(["$c", function($c) {
         c;
-    }]).filter("foo", ["$d","$e", function($d, $e) {
+    }]).filter("foo", ["$d", "$e", function($d, $e) {
         d;
-    }]).animation("foo", ["$f","$g", function($f, $g) {
+    }]).animation("foo", ["$f", "$g", function($f, $g) {
         e;
     }]);
 
-angular.module("MyMod").directive("foo", ["$a","$b", function($a, $b) {
+angular.module("MyMod").directive("foo", ["$a", "$b", function($a, $b) {
     a;
 }]).provider("foo", function() {
         return {
-            $get: ["$scope","$timeout", function($scope, $timeout) {
+            $get: ["$scope", "$timeout", function($scope, $timeout) {
                 bar;
             }]};
     }).value("foo", "bar")
@@ -122,21 +122,21 @@ angular.module("MyMod").directive("foo", ["$a","$b", function($a, $b) {
         b;
     }).config(["$c", function($c) {
         c;
-    }]).filter("foo", ["$d","$e", function($d, $e) {
+    }]).filter("foo", ["$d", "$e", function($d, $e) {
         d;
-    }]).animation("foo", ["$f","$g", function($f, $g) {
+    }]).animation("foo", ["$f", "$g", function($f, $g) {
         e;
     }]);
 
 // $provide
-angular.module("MyMod").directive("foo", ["$a","$b", function($a, $b) {
-    $provide.decorator("foo", ["$scope","$timeout", function($scope, $timeout) {
+angular.module("MyMod").directive("foo", ["$a", "$b", function($a, $b) {
+    $provide.decorator("foo", ["$scope", "$timeout", function($scope, $timeout) {
         a;
     }]);
-    $provide.factory("bar", ["$timeout","$scope", function($timeout, $scope) {
+    $provide.factory("bar", ["$timeout", "$scope", function($timeout, $scope) {
         b;
     }]);
-    $provide.animation("baz", ["$scope","$timeout", function($scope, $timeout) {
+    $provide.animation("baz", ["$scope", "$timeout", function($scope, $timeout) {
         c;
     }]);
 }]);


### PR DESCRIPTION
Hi,

The lack of spaces in the generated code (`["$scope","$location","$http"]`, etc.) was bothering me; I feel it's the responsibility of a JS minifier to remove them.  Since this is the fault of `JSON.stringify()`, and all we're really doing is building an array, I replaced these calls with a custom function:

``` js
function stringify(arr) {
    return "[" + arr.map(function(arg) {
        return '"' + arg.name + '"';
    }).join(", ") + "]";
}
```

(Potential bonus: may be faster)

If you don't like this as default behavior, would you be amenable to a configuration option?

My use case:

I want to run `ng-annotate` on source code; not anything processed in any manner.  Would rather not use [ngmin](https://github.com/btford/ngmin) as I feel it takes too many liberties (in addition to not having in-place annotating).  So without this patch, I'd have to add another build step to beautify the code, and I don't really want to deal with configuring [js-beautify](https://github.com/einars/js-beautify).  

thanks for this tool,
Chris
