### PR TITLE
Annotate single-argument state declarations

### DIFF
--- a/ng-annotate-main.js
+++ b/ng-annotate-main.js
@@ -70,20 +70,22 @@ function matchUiRouter(node) {
         return false;
     }
 
-    if (args.length !== 2) {
+    var configArg;
+    if (args.length === 2) {
+        const firstArgIsStringLiteral = (args[0].type === "Literal" && is.string(args[0].value));
+        if (!firstArgIsStringLiteral) {
+            return false;
+        }
+        configArg = args[1];
+    } else if (args.length === 1) {
+        configArg = args[0];
+    }
+
+    if (configArg.type !== "ObjectExpression") {
         return false;
     }
 
-    const firstArgIsStringLiteral = (args[0].type === "Literal" && is.string(args[0].value));
-    if (!firstArgIsStringLiteral) {
-        return false;
-    }
-
-    if (args[1].type !== "ObjectExpression") {
-        return false;
-    }
-
-    const props = args[1].properties;
+    const props = configArg.properties;
     const res = [
         matchProp("controller", props),
         matchProp("controllerProvider", props),

--- a/tests/original.js
+++ b/tests/original.js
@@ -186,8 +186,13 @@ $stateProvider.state("myState", {
         f;
     },
 }).state("myState2", {
-        controller: function($scope) {},
-    });
+    controller: function($scope) {},
+}).state({
+    name: "myState3",
+    controller: function($scope, simpleObj, promiseObj, translations) {
+        c;
+    },
+});
 $urlRouterProvider.when("", function($match) { a; });
 $urlRouterProvider.otherwise("", function($location) { a; });
 $urlRouterProvider.rule(function($location) { a; });

--- a/tests/with_annotations.js
+++ b/tests/with_annotations.js
@@ -186,8 +186,13 @@ $stateProvider.state("myState", {
         f;
     },
 }).state("myState2", {
-        controller: ["$scope", function($scope) {}],
-    });
+    controller: ["$scope", function($scope) {}],
+}).state({
+    name: "myState3",
+    controller: ["$scope", "simpleObj", "promiseObj", "translations", function($scope, simpleObj, promiseObj, translations) {
+        c;
+    }],
+});
 $urlRouterProvider.when("", ["$match", function($match) { a; }]);
 $urlRouterProvider.otherwise("", ["$location", function($location) { a; }]);
 $urlRouterProvider.rule(["$location", function($location) { a; }]);

--- a/tests/with_annotations_single.js
+++ b/tests/with_annotations_single.js
@@ -186,8 +186,13 @@ $stateProvider.state("myState", {
         f;
     },
 }).state("myState2", {
-        controller: ['$scope', function($scope) {}],
-    });
+    controller: ['$scope', function($scope) {}],
+}).state({
+    name: "myState3",
+    controller: ['$scope', 'simpleObj', 'promiseObj', 'translations', function($scope, simpleObj, promiseObj, translations) {
+        c;
+    }],
+});
 $urlRouterProvider.when("", ['$match', function($match) { a; }]);
 $urlRouterProvider.otherwise("", ['$location', function($location) { a; }]);
 $urlRouterProvider.rule(['$location', function($location) { a; }]);


### PR DESCRIPTION
Annotate single-argument form of state declarations.

Consider this unannotated form:

``` javascript
$stateProvider.state({
  name: "myState",
  controller: function($scope) { ... }
});
```

Annotation should be as follows:

``` javascript
$stateProvider.state({
  name: "myState",
  controller: ["$scope", function($scope) { ... }]
});
```

We could potentially scold the user if they attempt to use this without including a `name` key in the object literal, but that seems out of scope for this PR.
