### PR TITLE
Annotate ui-router view resolve blocks

### DIFF
--- a/ng-annotate-main.js
+++ b/ng-annotate-main.js
@@ -91,12 +91,15 @@ function matchUiRouter(node) {
 
 
     // {resolve: ..}
-    const resolveObject = matchProp("resolve", props);
-    if (resolveObject && resolveObject.type === "ObjectExpression") {
-        resolveObject.properties.forEach(function(prop) {
-            res.push(prop.value);
-        });
-    }
+    function addUiRouterResolves(props) {
+        const resolveObject = matchProp("resolve", props);
+        if (resolveObject && resolveObject.type === "ObjectExpression") {
+            resolveObject.properties.forEach(function(prop) {
+                res.push(prop.value);
+            });
+        }
+    };
+    addUiRouterResolves(props);
 
     // {view: ...}
     const viewObject = matchProp("views", props);
@@ -105,6 +108,14 @@ function matchUiRouter(node) {
             if (prop.value.type === "ObjectExpression") {
                 res.push(matchProp("controller", prop.value.properties));
                 res.push(matchProp("templateProvider", prop.value.properties));
+
+                const viewResolvesObject = prop.value;
+
+                if (viewResolvesObject.type !== "ObjectExpression") {
+                    return false;
+                }
+
+                addUiRouterResolves(viewResolvesObject.properties);
             }
         });
     }

--- a/tests/original.js
+++ b/tests/original.js
@@ -156,9 +156,14 @@ $stateProvider.state("myState", {
     },
     views: {
         viewa: {
-            controller: function($scope) {},
+            controller: function($scope, myParam) {},
             templateProvider: function($scope) {},
             dontAlterMe: function(arg) {},
+            resolve: {
+                myParam: function($stateParams) {
+                    return $stateParams.paramFromDI;
+                }
+            },
         },
         viewb: {
             dontAlterMe: function(arg) {},

--- a/tests/with_annotations.js
+++ b/tests/with_annotations.js
@@ -156,9 +156,14 @@ $stateProvider.state("myState", {
     },
     views: {
         viewa: {
-            controller: ["$scope", function($scope) {}],
+            controller: ["$scope", "myParam", function($scope, myParam) {}],
             templateProvider: ["$scope", function($scope) {}],
             dontAlterMe: function(arg) {},
+            resolve: {
+                myParam: ["$stateParams", function($stateParams) {
+                    return $stateParams.paramFromDI;
+                }]
+            },
         },
         viewb: {
             dontAlterMe: function(arg) {},

--- a/tests/with_annotations_single.js
+++ b/tests/with_annotations_single.js
@@ -156,9 +156,14 @@ $stateProvider.state("myState", {
     },
     views: {
         viewa: {
-            controller: ['$scope', function($scope) {}],
+            controller: ['$scope', 'myParam', function($scope, myParam) {}],
             templateProvider: ['$scope', function($scope) {}],
             dontAlterMe: function(arg) {},
+            resolve: {
+                myParam: ['$stateParams', function($stateParams) {
+                    return $stateParams.paramFromDI;
+                }]
+            },
         },
         viewb: {
             dontAlterMe: function(arg) {},


### PR DESCRIPTION
Resolve blocks nested within views are not currently annotated. This PR addresses that.

``` javascript
$stateProvider.state({
  name: "myState",
  views: {
    viewa: {
      controller: function($scope, paramAlpha, paramBeta) { ... },
      resolve: {
        paramAlpha: function($stateParams) { ... },
        paramBeta: function($stateParams) { ... },
      },
      viewb: { ... }
    }
  }
);
```

``` javascript
$stateProvider.state({
  name: "myState",
  views: {
    viewa: {
      controller: ["$scope", "paramAlpha", "paramBeta", function($scope, paramAlpha, paramBeta) { ... }],
      resolve: {
        paramAlpha: ["$stateParams", function($stateParams) { ... }],
        paramBeta: ["$stateParams", function($stateParams) { ... }],
      },
      viewb: { ... }
    }
  }
);
```
