### PR TITLE
added support for 'myObj.myMod.controller'

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ If ng-annotate does not handle a construct you're using, if there's a bug or if 
 request then please [file an issue](https://github.com/olov/ng-annotate/issues?state=open).
 
 
+## Tests
+The tests annotate `tests/original.js` and diff the result with `tests/with_annotations.js`
+and `tests/with_annotations_single.js`.
+If a test fails it will output the the diff.
+You can run the tests with `node --harmony run-tests.js`.
+
 ## Performance
 ng-annotate is designed to be very fast (in general limited by parse speed).
 It traverses the AST exactly once and transforms it without the need for an AST -> source

--- a/ng-annotate-main.js
+++ b/ng-annotate-main.js
@@ -125,6 +125,14 @@ function matchRegular(node, re) {
         return is.string(node.name) && (!re || re.test(node.name));
     }
 
+    // Medium form: *.*.controller("MyCtrl", function($scope, $timeout) {});
+    function isMediumDef(node, re) {
+        if (node.type === "MemberExpression" && is.object(node.object) && is.object(node.property) && is.string(node.object.name) && is.string(node.property.name)) {
+            return (!re || re.test(node.object.name + "." + node.property.name));
+        }
+        return false;
+    }
+
     // Long form: angular.module(*).controller("MyCtrl", function($scope, $timeout) {});
     function isLongDef(node) {
         return node.callee &&
@@ -145,7 +153,7 @@ function matchRegular(node, re) {
     if (!obj || !prop) {
         return false;
     }
-    const matchAngularModule = (obj.$chained || isShortDef(obj, re) || isLongDef(obj)) &&
+    const matchAngularModule = (obj.$chained || isShortDef(obj, re) || isMediumDef(obj, re) || isLongDef(obj)) &&
         is.someof(prop.name, ["provider", "value", "constant", "config", "factory", "directive", "filter", "run", "controller", "service", "decorator", "animation"]);
     if (!matchAngularModule) {
         return false;

--- a/tests/original.js
+++ b/tests/original.js
@@ -109,6 +109,11 @@ myMod.directive("foo", function($a, $b) {
         e;
     });
 
+// object property
+var myObj;
+myObj.myMod = angular.module("MyMod");
+myObj.myMod.controller("foo", function($scope, $timeout) {});
+
 angular.module("MyMod").directive("foo", function($a, $b) {
     a;
 }).provider("foo", function() {

--- a/tests/with_annotations.js
+++ b/tests/with_annotations.js
@@ -109,6 +109,11 @@ myMod.directive("foo", ["$a", "$b", function($a, $b) {
         e;
     }]);
 
+// object property
+var myObj;
+myObj.myMod = angular.module("MyMod");
+myObj.myMod.controller("foo", ["$scope", "$timeout", function($scope, $timeout) {}]);
+
 angular.module("MyMod").directive("foo", ["$a", "$b", function($a, $b) {
     a;
 }]).provider("foo", function() {

--- a/tests/with_annotations_single.js
+++ b/tests/with_annotations_single.js
@@ -109,6 +109,11 @@ myMod.directive("foo", ['$a', '$b', function($a, $b) {
         e;
     }]);
 
+// object property
+var myObj;
+myObj.myMod = angular.module("MyMod");
+myObj.myMod.controller("foo", ['$scope', '$timeout', function($scope, $timeout) {}]);
+
 angular.module("MyMod").directive("foo", ['$a', '$b', function($a, $b) {
     a;
 }]).provider("foo", function() {


### PR DESCRIPTION
I might just be the only one using angular like this, but asuming I'm not the only one it would be nice to have support for this way of doing things.

``` javascript
/** app.js **/
var blocktrail = angular.module('blocktrail', ['blocktrail.address', 'blocktrail.block']);

/** address/init.js **/
blocktrail.address = angular.module('blocktrail.address', []);
blocktrail.address.config(function($stateProvider) {});

/** address/controllers.js **/
blocktrail.address.controller('AddressController', function($state) {});

/** block/init.js **/
blocktrail.block = angular.module('blocktrail.address', []);
```

I also updated the README on how to run the tests because I had to good to figure out that I needed to add --harmony :D
