### PR TITLE
fix: return required plugin

### DIFF
--- a/ng-annotate.js
+++ b/ng-annotate.js
@@ -118,7 +118,7 @@ function runAnnotate(err, src) {
             }
             // the require below may throw an exception on parse-error
             try {
-                require(absPath)
+                return require(absPath);
             } catch (e) {
                 // node will already print file:line and offending line to stderr
                 exit(fmt("error: couldn't require(\"{0}\")", absPath));


### PR DESCRIPTION
Plugins were required but not returned from the Array.prototype.map function,
therefore they were never actually loaded, causing the error:

```
TypeError: Cannot call method 'init' of undefined
```
