### PR TITLE
Add note about the new middleman-ngannotate gem to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ automatically so you don't have to think about it.
 * [Rails asset pipeline](http://guides.rubyonrails.org/asset_pipeline.html): [ngannotate-rails](https://rubygems.org/gems/ngannotate-rails) by [Kari Ikonen](https://github.com/kikonen)
 * [Grails asset pipeline](https://github.com/bertramdev/asset-pipeline): [angular-annotate-asset-pipeline](https://github.com/craigburke/angular-annotate-asset-pipeline) by [Craig Burke](https://github.com/craigburke)
 * [Webpack](http://webpack.github.io/): [ng-annotate-webpack-plugin](https://www.npmjs.org/package/ng-annotate-webpack-plugin) by [Chris Liechty](https://github.com/cliechty)
+* [Middleman](http://middlemanapp.com/): [middleman-ngannotate](http://rubygems.org/gems/middleman-ngannotate) by [Michael Siebert](https://github.com/siebertm)
 * Something missing? Contributions welcome - create plugin and submit a README pull request!
 
 


### PR DESCRIPTION
I just created a gem plugin for middleman using ng-annotate, shamelessly basing my work in ngannotate-rails and middleman-ngmin (thanks guys!)

Added it to the README.

Thanks!
