### PR TITLE
Describe options in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,3 +311,67 @@ var errorstringArray = res.errors;
 var transformedSource = res.src;
 var transformedSourceMap = res.map;
 ```
+
+## Options
+
+These options may be provided in the *options* object:
+
+#### __a__ or __add__
+
+add dependency injection annotations where non-existing
+type: `Boolean`
+default: `true`
+
+#### __r__ or __remove__
+
+remove all existing dependency injection annotations
+type: `Boolean`
+default: `true`
+  
+#### __o__
+
+write output to <file>. output is written to stdout by default
+type: `string`
+default: `undefined` 
+
+#### sourcemap
+
+generate an inline sourcemap
+type: `Boolean`
+default: `true`
+
+#### sourceroot
+
+set the sourceRoot property of the generated sourcemap
+type: `String`
+default: `undefined`
+
+#### single_quotes
+
+use single quotes (`'`) instead of double quotes (`"`)
+type: `Boolean`
+default: `true`
+
+#### regexp
+
+detect short form myMod.controller(...) iff myMod matches regexp
+type: `RegExp`
+default: `undefined`
+
+#### rename
+
+rename declarations and annotated references
+type: `String` of format `'oldname1 newname1 oldname2 newname2 <...>'`
+default: `''`
+
+#### plugin
+
+use plugin with path (experimental)
+type: `Array`
+default `undefined`
+
+#### stats
+
+print statistics on stderr (experimental)
+type: `Boolean`
+default: `true`

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ var transformedSourceMap = res.map;
 
 These options may be provided in the *options* object:
 
-#### __a__ or __add__
+#### a, add
 
 add dependency injection annotations where non-existing
 
@@ -324,7 +324,7 @@ type: `Boolean`
 
 default: `true`
 
-#### __r__ or __remove__
+#### r, remove
 
 remove all existing dependency injection annotations
 
@@ -332,7 +332,7 @@ type: `Boolean`
 
 default: `true`
   
-#### __o__
+#### o
 
 write output to <file>. output is written to stdout by default
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ var transformedSourceMap = res.map;
 
 These options may be provided in the *options* object:
 
-#### a, add
+### a, add
 
 add dependency injection annotations where non-existing
 
@@ -324,23 +324,43 @@ type: `Boolean`
 
 default: `true`
 
-#### r, remove
+#### Examples
+
+```js
+options = {a: false}
+options = {add: false}
+```
+
+### r, remove
 
 remove all existing dependency injection annotations
 
 type: `Boolean`
 
 default: `true`
+
+#### Example
+
+```js
+options = {r: false}
+options = {remove: false}
+```
   
-#### o
+### o
 
 write output to <file>. output is written to stdout by default
 
 type: `string`
 
-default: `undefined` 
+default: `undefined`
 
-#### sourcemap
+#### Example
+
+```js
+options = {o: 'annotated-file.js'}
+```
+
+### sourcemap
 
 generate an inline sourcemap
 
@@ -348,7 +368,13 @@ type: `Boolean`
 
 default: `true`
 
-#### sourceroot
+#### Example
+
+```js
+options = {sourcemap: false}
+```
+
+### sourceroot
 
 set the sourceRoot property of the generated sourcemap
 
@@ -356,7 +382,13 @@ type: `String`
 
 default: `undefined`
 
-#### single_quotes
+#### Example
+
+```js
+options = {sourceroot: '../js/'}
+```
+
+### single_quotes
 
 use single quotes (`'`) instead of double quotes (`"`)
 
@@ -364,7 +396,13 @@ type: `Boolean`
 
 default: `true`
 
-#### regexp
+#### Example
+
+```js
+options = {single_quotes: false}
+```
+
+### regexp
 
 detect short form myMod.controller(...) iff myMod matches regexp
 
@@ -372,7 +410,13 @@ type: `RegExp`
 
 default: `undefined`
 
-#### rename
+#### Example
+
+```js
+options = {regexp: /myMod/}
+```
+
+### rename
 
 rename declarations and annotated references
 
@@ -380,7 +424,13 @@ type: `String` of format `'oldname1 newname1 oldname2 newname2 <...>'`
 
 default: `''`
 
-#### plugin
+#### Example
+
+```js
+options = {rename: 'oldname1 newname1 oldname2 newname2'}
+```
+
+### plugin
 
 use plugin with path (experimental)
 
@@ -388,10 +438,22 @@ type: `Array`
 
 default `undefined`
 
-#### stats
+#### Example
+
+```js
+options = {plugin: ['path/to/plugin1']}
+```
+
+### stats
 
 print statistics on stderr (experimental)
 
 type: `Boolean`
 
 default: `true`
+
+#### Example
+
+```js
+options = {stats: false}
+```

--- a/README.md
+++ b/README.md
@@ -319,59 +319,79 @@ These options may be provided in the *options* object:
 #### __a__ or __add__
 
 add dependency injection annotations where non-existing
+
 type: `Boolean`
+
 default: `true`
 
 #### __r__ or __remove__
 
 remove all existing dependency injection annotations
+
 type: `Boolean`
+
 default: `true`
   
 #### __o__
 
 write output to <file>. output is written to stdout by default
+
 type: `string`
+
 default: `undefined` 
 
 #### sourcemap
 
 generate an inline sourcemap
+
 type: `Boolean`
+
 default: `true`
 
 #### sourceroot
 
 set the sourceRoot property of the generated sourcemap
+
 type: `String`
+
 default: `undefined`
 
 #### single_quotes
 
 use single quotes (`'`) instead of double quotes (`"`)
+
 type: `Boolean`
+
 default: `true`
 
 #### regexp
 
 detect short form myMod.controller(...) iff myMod matches regexp
+
 type: `RegExp`
+
 default: `undefined`
 
 #### rename
 
 rename declarations and annotated references
+
 type: `String` of format `'oldname1 newname1 oldname2 newname2 <...>'`
+
 default: `''`
 
 #### plugin
 
 use plugin with path (experimental)
+
 type: `Array`
+
 default `undefined`
 
 #### stats
 
 print statistics on stderr (experimental)
+
 type: `Boolean`
+
 default: `true`


### PR DESCRIPTION
I just added a description of the options to the README. I believe I correctly described them. I copied the format of [JSCS's overview file](https://github.com/jscs-dev/node-jscs/blob/master/OVERVIEW.md).