### PR TITLE
"ngInject" directive can be anywhere inside a function

### DIFF
--- a/nginject.js
+++ b/nginject.js
@@ -84,13 +84,13 @@ function matchPrologueDirectives(prologueDirectives, node) {
     let found = null;
     for (let i = 0; i < body.length; i++) {
         if (body[i].type !== "ExpressionStatement") {
-            break;
+            continue;
         }
 
         const expr = body[i].expression;
         const isStringLiteral = (expr.type === "Literal" && typeof expr.value === "string");
         if (!isStringLiteral) {
-            break;
+            continue;
         }
 
         if (prologueDirectives.indexOf(expr.value) >= 0) {

--- a/tests/original.js
+++ b/tests/original.js
@@ -714,6 +714,12 @@ var foos3 = function($scope) {
     "use strict"; "ngInject";
 };
 
+var foos4 = function($scope) {
+    var someVariable = 1;
+    var someOtherVariable = 2;
+    "ngInject";
+};
+
 var dual1 = function(a) { "ngInject" }, dual2 = function(b) { "ngInject" };
 
 g(function(c) {

--- a/tests/with_annotations.js
+++ b/tests/with_annotations.js
@@ -739,6 +739,13 @@ var foos3 = function($scope) {
 };
 foos3.$inject = ["$scope"];
 
+var foos4 = function($scope) {
+    var someVariable = 1;
+    var someOtherVariable = 2;
+    "ngInject";
+};
+foos4.$inject = ["$scope"];
+
 var dual1 = function(a) { "ngInject" }, dual2 = function(b) { "ngInject" };
 dual1.$inject = ["a"];
 dual2.$inject = ["b"];


### PR DESCRIPTION
This solves [issue#152](https://github.com/olov/ng-annotate/issues/152)

Solving this issue is a pretty big priority for us since we use Coffeescript classes a lot in our codebase. As described in the issue above, none of the workarounds work in our case so scanning the full body of the function for "ngInject" seems to be the only option.

matchPrologueDirectives will now scan the whole body of the function instead of breaking after the first token.
The performance impact is minimal. I ran the performance test a thousand times and compared to the old version and it was slower by up to 2%.

If this is not acceptable, I could put it behind a flag, such as --fullscan.