### PR TITLE
Added new property "inMap" to "mapOpts" to pass in a map object.

### DIFF
--- a/generate-sourcemap.js
+++ b/generate-sourcemap.js
@@ -101,7 +101,7 @@ function compareLoc(a, b) {
 }
 
 module.exports = function generateSourcemap(result, src, nodePositions, fragments, mapOpts) {
-    const existingMap = convertSourceMap.fromSource(src);
+    const existingMap = mapOpts.inMap ? convertSourceMap.fromSource(mapOpts.inMap) : convertSourceMap.fromSource(src);
     const existingMapObject = existingMap && existingMap.toObject();
     const inFile = (existingMapObject && existingMapObject.file) || mapOpts.inFile || "source.js";
     const sourceRoot = (existingMapObject && existingMapObject.sourceRoot) || mapOpts.sourceRoot;


### PR DESCRIPTION
Introduced a new property `mapOpts.inMap` to `function generateSourcemap()` in `generate-sourcemap.js`. This property may contain a sourcemap that has been read through `options.map` in `function ngAnnotate()`. 

For now one can access this only using the library API. I have deliberately not touched the CLI portion as I think that the library author is in a better position to make that change.

My suggestion would be to allow `--inMapFile` for the command line which can take the path from which the source map can be read into `config.map.inMap`. For the library user, it will be their responsibility to read the file and map it to `config.map.inMap`.  Eventually, the code in `function generateSourcemap()` can check if it is a string or an object to use JSON or Object source map transformation at the level of *convert-source-map* library.

Please be gentle, this is my first PR :)