### PR TITLE
Support new Angular's module methods: decorator and component

### DIFF
--- a/ng-annotate-main.js
+++ b/ng-annotate-main.js
@@ -315,7 +315,7 @@ function matchRegular(node, ctx) {
     }
 
     const matchAngularModule = (obj.$chained === chainedRegular || isReDef(obj, ctx) || isLongDef(obj)) &&
-        is.someof(method.name, ["provider", "value", "constant", "bootstrap", "config", "factory", "directive", "filter", "run", "controller", "service", "animation", "invoke", "store"]);
+        is.someof(method.name, ["provider", "value", "constant", "bootstrap", "config", "factory", "directive", "filter", "run", "controller", "service", "animation", "invoke", "store", "decorator"]);
     if (!matchAngularModule) {
         return false;
     }

--- a/ng-annotate-main.js
+++ b/ng-annotate-main.js
@@ -315,7 +315,7 @@ function matchRegular(node, ctx) {
     }
 
     const matchAngularModule = (obj.$chained === chainedRegular || isReDef(obj, ctx) || isLongDef(obj)) &&
-        is.someof(method.name, ["provider", "value", "constant", "bootstrap", "config", "factory", "directive", "filter", "run", "controller", "service", "animation", "invoke", "store", "decorator"]);
+        is.someof(method.name, ["provider", "value", "constant", "bootstrap", "config", "factory", "directive", "filter", "run", "controller", "service", "animation", "invoke", "store", "decorator", "component"]);
     if (!matchAngularModule) {
         return false;
     }


### PR DESCRIPTION
Fixes #204 

Also, adds support for new `angular.module(...).component()` function that is about to be introduced in Angular 1.5.