### PR TITLE
Add es6 option

### DIFF
--- a/ng-annotate-main.js
+++ b/ng-annotate-main.js
@@ -1051,6 +1051,7 @@ module.exports = function ngAnnotate(src, options) {
 
     const quot = options.single_quotes ? "'" : '"';
     const re = (options.regexp ? new RegExp(options.regexp) : /^[a-zA-Z0-9_\$\.\s]+$/);
+    const es6 = options.es6 ? options.es6 : false;
     const rename = new stringmap();
     if (options.rename) {
         options.rename.forEach(function(value) {
@@ -1080,6 +1081,7 @@ module.exports = function ngAnnotate(src, options) {
             locations: true,
             ranges: true,
             onComment: comments,
+            sourceType: es6 ? "module" : "script",
         });
         stats.parser_parse_t1 = Date.now();
     } catch(e) {

--- a/ng-annotate.js
+++ b/ng-annotate.js
@@ -39,7 +39,11 @@ const optimist = require("optimist")
         describe: "use single quotes (') instead of double quotes (\")",
     })
     .options("regexp", {
-        describe: "detect short form myMod.controller(...) iff myMod matches regexp",
+        describe: "detect short form myMod.controller(...) if myMod matches regexp",
+    })
+    .options("es6", {
+        boolean: true,
+        describe: "enable es6 compatibility",
     })
     .options("rename", {
         describe: "rename declarations and annotated references\n" +
@@ -132,7 +136,7 @@ function runAnnotate(err, src) {
         config.inFile = filename;
     }
 
-    ["add", "remove", "o", "regexp", "rename", "single_quotes", "plugin", "enable", "stats"].forEach(function(opt) {
+    ["add", "remove", "o", "regexp", "es6", "rename", "single_quotes", "plugin", "enable", "stats"].forEach(function(opt) {
         if (opt in argv) {
             config[opt] = argv[opt];
         }

--- a/run-tests.js
+++ b/run-tests.js
@@ -126,6 +126,11 @@ function run(ngAnnotate) {
     console.log("testing removing existing $inject annotations");
     test(slurp("tests/has_inject_removed.js"), ngAnnotate(slurp("tests/has_inject.js"), {remove: true}).src);
 
+    console.log("testing es6");
+    const original_wrapped = slurp("tests/es6.original.js");
+    const annotated_wrapper = ngAnnotate(original_wrapped, {add: true, es6: true}).src;
+    test(slurp("tests/es6.annotated.js"), annotated_wrapper, "es6.original.js");
+
     console.log("testing sourcemaps");
     const originalSourcemaps = slurp("tests/sourcemaps.coffee");
     const compiledSourcemaps = coffee.compile(originalSourcemaps, { sourceFiles: ["sourcemaps.coffee"], generatedFile: "sourcemaps.js", sourceMap: true });

--- a/scopetools.js
+++ b/scopetools.js
@@ -34,8 +34,17 @@ function createScopes(node, parent) {
     } else if (node.type === "VariableDeclaration") {
         // Variable declarations names goes in current scope
         node.declarations.forEach(function(declarator) {
-            const name = declarator.id.name;
-            node.$scope.add(name, node.kind, declarator.id, declarator.range[1]);
+            // Destructuring es6
+            if(declarator.id.properties) {
+                declarator.id.properties.forEach(function(destructuredDeclarator) {
+                    const destructVarName = destructuredDeclarator.value.name;
+                    node.$scope.add(destructVarName, node.kind, destructuredDeclarator, destructuredDeclarator.range[1]);
+                });
+            // Normal variable declaration
+            } else {
+                const variableName = declarator.id.name;
+                node.$scope.add(variableName, node.kind, declarator.id, declarator.range[1]);
+            }
         });
 
     } else if (isFunction(node)) {
@@ -61,8 +70,11 @@ function createScopes(node, parent) {
             }
         }
 
+        let paramName;
         node.params.forEach(function(param) {
-            node.$scope.add(param.name, "param", param, null);
+            // Args default value (es6)
+            paramName = param.left ? param.left.name : param.name;
+            node.$scope.add(paramName, "param", param, null);
         });
 
     } else if (isForWithConstLet(node) || isForInOfWithConstLet(node)) {

--- a/tests/es6.annotated.js
+++ b/tests/es6.annotated.js
@@ -1,0 +1,10 @@
+module.exports = {'test': 'name'}
+
+import angular from 'angular'
+
+angular.module(module.exports.test, ['deps']).factory('Example', ["CustomService", function (CustomService) {
+}])
+
+function es6DefaultArg(firstarg = "defaultValue"){}
+
+const {destruc, turing} = {a:1, b:2}

--- a/tests/es6.original.js
+++ b/tests/es6.original.js
@@ -1,0 +1,10 @@
+module.exports = {'test': 'name'}
+
+import angular from 'angular'
+
+angular.module(module.exports.test, ['deps']).factory('Example', function (CustomService) {
+})
+
+function es6DefaultArg(firstarg = "defaultValue"){}
+
+const {destruc, turing} = {a:1, b:2}


### PR DESCRIPTION
Enables sourceType mode "module" for acorn, to manage `import`.

It should solve #227, #237 and https://github.com/huston007/ng-annotate-loader/issues/17.

A few changes to the scope tools where needed to support es6 language additions.