### PR TITLE
Feat support acorn options sourceType and ecmaVersion

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -15,6 +15,11 @@ Use the `--sourcemap` option to generate an inline sourcemap.
 
 Use the `--sourceroot` option to set the sourceRoot property of the generated sourcemap.
 
+Use the `--sourcetype` option to indicate the mode the code should be parsed in.
+Can be either "script" or "module". This influences global strict mode and parsing of import and export declarations.
+
+Use the `--ecmaversion` option to indicate the ECMAScript version to parse. Must be either 3, 5, 6 (2015), 7 (2016), or 8 (2017). This influences support for strict mode, the set of reserved words, and support for new syntax features. Default is 7.
+
 Use the `--single_quotes` option to output `'$scope'` instead of `"$scope"`.
 
 Use the `--regexp` option to restrict matching further or to expand matching.

--- a/ng-annotate-main.js
+++ b/ng-annotate-main.js
@@ -1075,7 +1075,8 @@ module.exports = function ngAnnotate(src, options) {
         stats.parser_parse_t0 = Date.now();
         // acorn
         ast = parser(src, {
-            ecmaVersion: 6,
+            ecmaVersion: options.ecmaversion || 6,
+            sourceType: options.sourcetype || 'script',
             allowReserved: true,
             locations: true,
             ranges: true,

--- a/ng-annotate.js
+++ b/ng-annotate.js
@@ -34,6 +34,13 @@ const optimist = require("optimist")
     .options("sourceroot", {
         describe: "set the sourceRoot property of the generated sourcemap"
     })
+    .options("sourcetype", {
+        describe: "mode the code should be parsed in (\"script\" or \"module\")",
+    })
+    .options("ecmaversion", {
+        describe: "ECMAScript version to parse\n" +
+        "Must be either 3, 5, 6 (2015), 7 (2016), or 8 (2017).",
+    })
     .options("single_quotes", {
         boolean: true,
         describe: "use single quotes (') instead of double quotes (\")",
@@ -132,7 +139,8 @@ function runAnnotate(err, src) {
         config.inFile = filename;
     }
 
-    ["add", "remove", "o", "regexp", "rename", "single_quotes", "plugin", "enable", "stats"].forEach(function(opt) {
+    ["add", "remove", "o", "regexp", "rename", "single_quotes", "plugin",
+        "enable", "stats", "sourcetype", "ecmaversion"].forEach(function(opt) {
         if (opt in argv) {
             config[opt] = argv[opt];
         }

--- a/run-tests.js
+++ b/run-tests.js
@@ -151,6 +151,11 @@ function run(ngAnnotate) {
     console.log("testing removing annotations (imported tests)");
     test(ngminOriginal, ngAnnotate(ngminAnnotated, {remove: true, regexp: "^myMod"}).src, "ngmin_original.js");
 
+    console.log("testing sourcetype 'module'");
+    const stm = slurp("tests/sourcetype-module.js");
+    const stmAnnotated = ngAnnotate(stm, { add: true, sourcetype: "module" }).src;
+    test(slurp("tests/sourcetype-module.annotated.js"), stmAnnotated, "sourcetype-module.annotated.js");
+
     // TODO generic test-runner code for finding and testing all optionals automatically
     // optionals angular-dashboard-framework adding annotations
     console.log("testing optionals/angular-dashboard-framework.js (adding annotations)");

--- a/tests/sourcetype-module.annotated.js
+++ b/tests/sourcetype-module.annotated.js
@@ -1,0 +1,13 @@
+var AppController = (function () {
+    AppController.$inject = ["$scope"];
+    function AppController($scope) {
+        "ngInject";
+        this.$scope = $scope;
+        this.title = 'AppController';
+    }
+    AppController.prototype.$onInit = function () {
+        console.log(this.$scope);
+    };
+    return AppController;
+}());
+export { AppController };

--- a/tests/sourcetype-module.js
+++ b/tests/sourcetype-module.js
@@ -1,0 +1,12 @@
+var AppController = (function () {
+    function AppController($scope) {
+        "ngInject";
+        this.$scope = $scope;
+        this.title = 'AppController';
+    }
+    AppController.prototype.$onInit = function () {
+        console.log(this.$scope);
+    };
+    return AppController;
+}());
+export { AppController };


### PR DESCRIPTION
Hi,

can we add support for the acorn options sourceType and ecmaVersion?

> - **sourceType**: Indicate the mode the code should be parsed in. Can be either "script" or "module". This influences global strict mode and parsing of import and export declarations.
> - **ecmaVersion**
Indicates the ECMAScript version to parse. Must be either 3, 5, 6 (2015), 7 (2016), or 8 (2017). This influences support for strict mode, the set of reserved words, and support for new syntax features. Default is 7. [[acorn]](https://github.com/ternjs/acorn#main-parser)

This would allow us to annotate code with es6 modules like in the following snippet:

```js
var AppController = (function () {
    function AppController($scope) {
        "ngInject";
        this.$scope = $scope;
        this.title = 'AppController';
    }
    AppController.prototype.$onInit = function () {
        console.log(this.$scope);
    };
    return AppController;
}());
export { AppController };
```

Currently if only need `sourcetype: "module"` but i thought it would be a good idea to support `ecmaversion` too. What do you think?

Cheers,
Fabian 

CC @loxy